### PR TITLE
Add software requirements and links between libraries.

### DIFF
--- a/footprints.md
+++ b/footprints.md
@@ -7,6 +7,11 @@ layout: default
 ## {{ page.title }}
 
 The KiCad footprint libraries are the individual `.pretty` directories. Each `.pretty` directory contains multiple `.kicad_mod` footprint files.
+These footprints are best used in combination with the official [symbol libs](https://kicad.github.io/symbols/) and [3d model libs](https://kicad.github.io/footprints/).
+
+## Requirements
+
+The files packaged here are intended for KiCad version 5 or nightly builds that support rounded rectangle and polygon pads.
 
 ## Updating via Git
 

--- a/packages3d.md
+++ b/packages3d.md
@@ -6,7 +6,9 @@ layout: default
 
 ## {{ page.title }}
 
-The KiCad 3D model libraries are the individual `.3dshapes` directories. Each directory directory contains multiple 3D model files, with the following supported file formats.
+The KiCad 3D model libraries are the individual `.3dshapes` directories.
+These 3d models are best used in combination with the official [footprint libs](https://kicad.github.io/footprints/).
+Each directory directory contains multiple 3D model files, with the following supported file formats.
 
 ### WRL
 

--- a/symbols.md
+++ b/symbols.md
@@ -7,6 +7,11 @@ layout: default
 ## {{ page.title }}
 
 The KiCad symbol libraries are the individual `.lib` files, with the corresponding `.dcm` files containing symbol metadata.
+These symbols are best used in combination with the official [footprint libs](https://kicad.github.io/footprints/).
+
+## Requirements
+
+The files packaged here are intended for KiCad version 5 or nightly builds that support the schematic library version 2.4 or newer.
 
 ## Updating via Git
 


### PR DESCRIPTION
@jkriege2, @evanshultz I added software requirement information to the download page.

As suggested by @bobc in https://github.com/KiCad/kicad-footprints/issues/283#issuecomment-359744307