### PR TITLE
put fp-lib-table and sym-lib-table in downloads

### DIFF
--- a/build_footprints.sh
+++ b/build_footprints.sh
@@ -10,5 +10,8 @@ cd $TRAVIS_BUILD_DIR
 rm _footprints/*.md
 rm _footprints/*.html
 
+# copy over footprint library table to downloads directory
+cp /home/travis/build/footprints/fp-lib-table $TRAVIS_BUILD_DIR/download/footprints/.
+
 # Generate footprint data
 python _scripts/gen_footprint_info.py /home/travis/build/footprints/*.pretty --script /home/travis/build/utils -v --download $TRAVIS_BUILD_DIR/download --output $TRAVIS_BUILD_DIR/_footprints

--- a/build_symbols.sh
+++ b/build_symbols.sh
@@ -10,5 +10,8 @@ cd $TRAVIS_BUILD_DIR
 rm _symbols/*.md
 rm _symbols/*.html
 
+# copy over symbol library table to downloads directory
+cp /home/travis/build/kicad-symbols/sym-lib-table $TRAVIS_BUILD_DIR/download/symbols/.
+
 # Generate symbol data
 python _scripts/gen_symbol_info.py /home/travis/build/kicad-symbols/*.lib --schlib /home/travis/build/utils/schlib --output $TRAVIS_BUILD_DIR/_symbols --download $TRAVIS_BUILD_DIR/download/ -v


### PR DESCRIPTION
I can imagine many cases where a user would want the fp-lib-table and sym-lib-table files that go along with all the symbol and footprint libraries that can be downloaded here. This change should allow those tables to be downloaded from

https://kicad.github.io/download/symbols/sym-lib-table
and
https://kicad.github.io/download/footprints/fp-lib-table

Not 100% sure if the permissions will be correct here, might need a `chmod o+r` after the `cp` here... 