### PR TITLE
Change GitHub links to GitLab in packages3d.md

### DIFF
--- a/footprints.md
+++ b/footprints.md
@@ -15,21 +15,21 @@ The files packaged here are intended for KiCad version 5 or nightly builds that 
 
 ## Updating via Git
 
-Users who wish to keep footprint libraries up to date can track the [https://github.com/kicad/kicad-footprints](https://github.com/kicad/kicad-footprints) GitHub repository.
+Users who wish to keep footprint libraries up to date can track the [https://gitlab.com/kicad/libraries/kicad-footprints](https://gitlab.com/kicad/libraries/kicad-footprints) GitLab repository.
 
 ## Contributing
 
-Users who wish to contribute to the footprint libraries can submit a pull request at [http://github.com/kicad/kicad-footprints](https://github.com/kicad/kicad-footprints)
+Users who wish to contribute to the footprint libraries can submit a merge request at [https://gitlab.com/kicad/libraries/kicad-footprints](https://gitlab.com/kicad/libraries/kicad-footprints).
 
 ## Library Releases
 
 The latest complete set of KiCad footprint libraries can be downloaded from the following link:
 
-[https://github.com/KiCad/kicad-footprints/archive/master.zip](https://github.com/KiCad/kicad-footprints/archive/master.zip)
+[https://gitlab.com/kicad/libraries/kicad-footprints/-/archive/master/kicad-footprints-master.zip](https://gitlab.com/kicad/libraries/kicad-footprints/-/archive/master/kicad-footprints-master.zip)
 
 Stable releases of the the footprint libraries can be found at:
 
-[https://github.com/kicad/kicad-footprints/releases](https://github.com/kicad/kicad-footprints/releases)
+[https://gitlab.com/kicad/libraries/kicad-footprints/-/releases](https://gitlab.com/kicad/libraries/kicad-footprints/-/releases)
 
 {% include fptable.html %}
 

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ layout: home
 
 # KiCad Libraries
 
-This site serves the latest KiCad libraries which are community contributed on the [KiCad github page](https://github.com/kicad).
+This site serves the latest KiCad libraries which are community contributed on the [KiCad GitLab page](https://gitlab.com/kicad).
 
 If you would like to contribute to the libraries, refer to the library contributing guide at [http://kicad-pcb.org/libraries/contribute](http://kicad-pcb.org/libraries/contribute).
 
@@ -25,11 +25,11 @@ Users who wish to keep up to date with the latest libraries should clone the KiC
 # External Links
 
 * [Official KiCad Website](http://kicad-pcb.org)
-* [KiCad GitHub Page](https://github.com/kicad)
+* [KiCad GitLab Page](https://gitlab.com/kicad)
 
 ---
 
-_This site is automatically generated and mirrors the latest library data available on the [KiCad GitHub page](https://github.com/kicad)._
+_This site is automatically generated and mirrors the latest library data available on the [KiCad GitLab page](https://gitlab.com/kicad)._
 
 _Library updates may take up to 48 hours to appear._
 

--- a/packages3d.md
+++ b/packages3d.md
@@ -20,23 +20,23 @@ STEP files are required for integration with MCAD software.
 
 ## Updating via Git
 
-Users who wish to keep 3D model libraries up to date can track the [https://github.com/kicad/kicad-packages3d](https://github.com/kicad/kicad-packages3d) GitHub repository.
+Users who wish to keep 3D model libraries up to date can track the [https://gitlab.com/kicad/libraries/kicad-packages3D](https://gitlab.com/kicad/libraries/kicad-packages3D) GitLab repository.
 
 ## Contributing
 
-Users who wish to contribute to the 3D model libraries can submit a pull request at [https://github.com/kicad/kicad-packages3d](https://github.com/kicad/kicad-packages3d).
+Users who wish to contribute to the 3D model libraries can submit a merge request at [https://gitlab.com/kicad/libraries/kicad-packages3D](https://gitlab.com/kicad/libraries/kicad-packages3D).
 
-Source files for 3D models can be found at [https://github.com/kicad/kicad-packages3d-source](https://github.com/kicad/kicad-packages3d-source).
+Source files for 3D models can be found at [https://gitlab.com/kicad/libraries/kicad-packages3D-source](https://gitlab.com/kicad/libraries/kicad-packages3D-source).
 
 ## Library Releases
 
 The latest complete set of KiCad 3D model libraries can be downloaded from the following link:
 
-[https://github.com/kicad/kicad-packages3d/archive/master.zip](https://github.com/kicad/kicad-packages3d/archive/master.zip)
+[https://gitlab.com/kicad/libraries/kicad-packages3D/-/archive/master/kicad-packages3D-master.zip](https://gitlab.com/kicad/libraries/kicad-packages3D/-/archive/master/kicad-packages3D-master.zip)
 
 Stable releases of the 3D model libraries can be found at:
 
-[https://github.com/kicad/kicad-packages3d/releases](https://github.com/kicad/kicad-packages3d/releases)
+[https://gitlab.com/kicad/libraries/kicad-packages3D/-/releases](https://gitlab.com/kicad/libraries/kicad-packages3D/-/releases)
 
 {% include pkg3dtable.html %}
 

--- a/symbols.md
+++ b/symbols.md
@@ -15,21 +15,21 @@ The files packaged here are intended for KiCad version 5 or nightly builds that 
 
 ## Updating via Git
 
-Users who wish to keep symbol libraries up to date can track the [https://github.com/kicad/kicad-symbols](https://github.com/kicad/kicad-symbols) GitHub repository.
+Users who wish to keep symbol libraries up to date can track the [https://gitlab.com/kicad/libraries/kicad-symbols](https://gitlab.com/kicad/libraries/kicad-symbols) GitLab repository.
 
 ## Contributing
 
-Users who wish to contribute to the symbols libraries can submit a pull request at [http://github.com/kicad/kicad-symbols](https://github.com/kicad/kicad-symbols)
+Users who wish to contribute to the symbols libraries can submit a merge request at [https://gitlab.com/kicad/libraries/kicad-symbols](https://gitlab.com/kicad/libraries/kicad-symbols).
 
 ## Library Releases
 
 The latest complete set of KiCad symbol libraries can be downloaded from the following link:
 
-[https://github.com/KiCad/kicad-symbols/archive/master.zip](https://github.com/KiCad/kicad-symbols/archive/master.zip)
+[https://gitlab.com/kicad/libraries/kicad-symbols/-/archive/master/kicad-symbols-master.zip](https://gitlab.com/kicad/libraries/kicad-symbols/-/archive/master/kicad-symbols-master.zip)
 
 Stable releases of the the symbol libraries can be found at:
 
-[https://github.com/kicad/kicad-symbols/releases](https://github.com/kicad/kicad-symbols/releases)
+[https://gitlab.com/kicad/libraries/kicad-symbols/-/releases](https://gitlab.com/kicad/libraries/kicad-symbols/-/releases)
 
 {% include symtable.html %}
 


### PR DESCRIPTION
I noticed the links on `packages3d.md` were all outdated, so I've updated them to point to the newer locations on GitLab instead.