### PR TITLE
Make it clear that these libraries are for v5

### DIFF
--- a/footprints.md
+++ b/footprints.md
@@ -6,20 +6,24 @@ layout: default
 
 ## {{ page.title }}
 
-The KiCad footprint libraries are the individual `.pretty` directories. Each `.pretty` directory contains multiple `.kicad_mod` footprint files.
-These footprints are best used in combination with the official [symbol libs](https://kicad.github.io/symbols/) and [3d model libs](https://kicad.github.io/packages3d/).
+**This page contains footprint libraries for KiCad version 5, which are very old. They are not appropriate for newer versions of KiCad. If you are using a modern KiCad version, see the library downloads available on the [KiCad website](https://www.kicad.org/libraries/download/).**
+
+The KiCad version 5 footprint libraries are the individual `.pretty` directories. Each `.pretty` directory contains multiple `.kicad_mod` footprint files.
+These footprints are best used in combination with the official [version 5 symbol libs](https://kicad.github.io/symbols/) and [version 5 3d model libs](https://kicad.github.io/packages3d/).
 
 ## Requirements
 
-The files packaged here are intended for KiCad version 5 or nightly builds that support rounded rectangle and polygon pads.
+The files packaged here are intended for KiCad version 5.
 
 ## Updating via Git
 
 Users who wish to keep footprint libraries up to date can track the [https://gitlab.com/kicad/libraries/kicad-footprints](https://gitlab.com/kicad/libraries/kicad-footprints) GitLab repository.
+Libraries for KiCad version 5 are no longer maintained.
 
 ## Contributing
 
 Users who wish to contribute to the footprint libraries can submit a merge request at [https://gitlab.com/kicad/libraries/kicad-footprints](https://gitlab.com/kicad/libraries/kicad-footprints).
+Libraries for KiCad version 5 are no longer maintained.
 
 ## Library Releases
 

--- a/index.md
+++ b/index.md
@@ -4,7 +4,9 @@ layout: home
 
 # KiCad Libraries
 
-This site serves the latest KiCad libraries which are community contributed on the [KiCad GitLab page](https://gitlab.com/kicad).
+This site serves the version 5 KiCad libraries. **The libraries archived here are old, out-of-date, and no longer maintained.** If you are using a newer KiCad version, see the library downloads available on the [KiCad website](https://www.kicad.org/libraries/download/).
+
+Modern versions of the libraries are community contributed on the [KiCad GitLab page](https://gitlab.com/kicad).
 
 If you would like to contribute to the libraries, refer to the library contributing guide at [https://www.kicad.org/libraries/contribute](https://www.kicad.org/libraries/contribute).
 
@@ -29,7 +31,7 @@ Users who wish to keep up to date with the latest libraries should clone the KiC
 
 ---
 
-_This site is automatically generated and mirrors the latest library data available on the [KiCad GitLab page](https://gitlab.com/kicad)._
+_This site is automatically generated and mirrors the latest KiCad version 5 library data available on the [KiCad GitLab page](https://gitlab.com/kicad)._
 
 _Library updates may take up to 48 hours to appear._
 

--- a/packages3d.md
+++ b/packages3d.md
@@ -6,8 +6,10 @@ layout: default
 
 ## {{ page.title }}
 
-The KiCad 3D model libraries are the individual `.3dshapes` directories.
-These 3d models are best used in combination with the official [footprint libs](https://kicad.github.io/footprints/).
+**This page contains 3D model libraries for KiCad version 5, which are very old. They are not appropriate for newer versions of KiCad. If you are using a modern KiCad version, see the library downloads available on the [KiCad website](https://www.kicad.org/libraries/download/).**
+
+The KiCad version 5 3D model libraries are the individual `.3dshapes` directories.
+These 3d models are best used in combination with the official [version 5 footprint libs](https://kicad.github.io/footprints/).
 Each directory directory contains multiple 3D model files, with the following supported file formats.
 
 ### WRL
@@ -21,10 +23,12 @@ STEP files are required for integration with MCAD software.
 ## Updating via Git
 
 Users who wish to keep 3D model libraries up to date can track the [https://gitlab.com/kicad/libraries/kicad-packages3D](https://gitlab.com/kicad/libraries/kicad-packages3D) GitLab repository.
+Libraries for KiCad version 5 are no longer maintained.
 
 ## Contributing
 
 Users who wish to contribute to the 3D model libraries can submit a merge request at [https://gitlab.com/kicad/libraries/kicad-packages3D](https://gitlab.com/kicad/libraries/kicad-packages3D).
+Libraries for KiCad version 5 are no longer maintained.
 
 Source files for 3D models can be found at [https://gitlab.com/kicad/libraries/kicad-packages3D-source](https://gitlab.com/kicad/libraries/kicad-packages3D-source).
 

--- a/symbols.md
+++ b/symbols.md
@@ -6,20 +6,24 @@ layout: default
 
 ## {{ page.title }}
 
-The KiCad symbol libraries are the individual `.lib` files, with the corresponding `.dcm` files containing symbol metadata.
-These symbols are best used in combination with the official [footprint libs](https://kicad.github.io/footprints/).
+**This page contains symbol libraries for KiCad version 5, which are very old. They are not appropriate for newer versions of KiCad. If you are using a modern KiCad version, see the library downloads available on the [KiCad website](https://www.kicad.org/libraries/download/).**
+
+The KiCad version 5 symbol libraries are the individual `.lib` files, with the corresponding `.dcm` files containing symbol metadata.
+These symbols are best used in combination with the official [version 5 footprint libs](https://kicad.github.io/footprints/).
 
 ## Requirements
 
-The files packaged here are intended for KiCad version 5 or nightly builds that support the schematic library version 2.4 or newer.
+The files packaged here are intended for KiCad version 5 (schematic library version 2.4).
 
 ## Updating via Git
 
 Users who wish to keep symbol libraries up to date can track the [https://gitlab.com/kicad/libraries/kicad-symbols](https://gitlab.com/kicad/libraries/kicad-symbols) GitLab repository.
+Libraries for KiCad version 5 are no longer maintained.
 
 ## Contributing
 
 Users who wish to contribute to the symbols libraries can submit a merge request at [https://gitlab.com/kicad/libraries/kicad-symbols](https://gitlab.com/kicad/libraries/kicad-symbols).
+Libraries for KiCad version 5 are no longer maintained.
 
 ## Library Releases
 


### PR DESCRIPTION
not for anything approximating modern kicad. Point to a better resource.